### PR TITLE
use api subdomain for sending heartbeats

### DIFF
--- a/helper/index.js
+++ b/helper/index.js
@@ -42,7 +42,7 @@ async function sendHeartbeat(options) {
     plugin: `camunda-modeler-wakatime/${VERSION}`
   };
 
-  const url = 'https://wakatime.com/api/v1/heartbeats';
+  const url = 'https://api.wakatime.com/api/v1/heartbeats';
 
   return await request.post({
     headers: {


### PR DESCRIPTION
The `api.wakatime.com` domain is better suited to handle incoming heartbeats.